### PR TITLE
Fixes issue #114

### DIFF
--- a/library/Businessprocess/Modification/NodeCreateAction.php
+++ b/library/Businessprocess/Modification/NodeCreateAction.php
@@ -5,6 +5,7 @@ namespace Icinga\Module\Businessprocess\Modification;
 use Icinga\Module\Businessprocess\BpConfig;
 use Icinga\Module\Businessprocess\BpNode;
 use Icinga\Module\Businessprocess\Node;
+use Icinga\Exception\ConfigurationError;
 
 class NodeCreateAction extends NodeAction
 {
@@ -95,7 +96,11 @@ class NodeCreateAction extends NodeAction
 
         foreach ($this->getProperties() as $key => $val) {
             if ($key === 'parentName') {
-                $config->getBpNode($val)->addChild($node);
+                try {
+                    $config->getBpNode($val)->addChild($node);
+                } catch (ConfigurationError $configError) {
+                    throw $configError;
+                }
                 continue;
             }
             $func = 'set' . ucfirst($key);

--- a/library/Businessprocess/Modification/ProcessChanges.php
+++ b/library/Businessprocess/Modification/ProcessChanges.php
@@ -145,6 +145,23 @@ class ProcessChanges
         $this->session->set($this->getSessionKey(), null);
         return $this;
     }
+    
+    /**
+    * Forget the last change that was made and remove it from the Session
+    *
+    * @return $this
+    */
+    public function clearLastElement()
+    {
+        $currentSession = $this->session->getAll();
+        $changes = array_pop($currentSession);
+
+        $lastElement = sizeOf($changes) - 1;
+        unset($changes[$lastElement]);
+
+        $this->session->set($this->getSessionKey(), $changes);
+        return $this;
+    }
 
     /**
      * Whether there are no stacked changes


### PR DESCRIPTION
After adding a node for a second time, an exception will appear. 
When clicking on the root node again, the problem-node is forgotten. Other pending changes are not touched.