### PR TITLE
BpNode: Count missing nodes in getStateSummary

### DIFF
--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -68,10 +68,15 @@ class BpNode extends Node
                     foreach ($counters as $k => $v) {
                         $this->counters[$k] += $v;
                     }
+                } elseif ($child->isMissing()) {
+                    $this->counters['MISSING']++;
                 } else {
                     $state = $child->getStateName();
                     $this->counters[$state]++;
                 }
+            }
+            if (! $this->hasChildren()) {
+                $this->counters['MISSING']++;
             }
         }
         return $this->counters;


### PR DESCRIPTION
Children that are missing should increment the counter, as well as
if no children are present.

So it's easy to find missing nodes following the counters.