### PR TITLE
WIP: Adding hostgroups to processes

### DIFF
--- a/application/controllers/ProcessController.php
+++ b/application/controllers/ProcessController.php
@@ -167,6 +167,8 @@ class ProcessController extends Controller
             $renderer->setUrl($this->url())
                 ->setPath($this->params->getValues('path'));
 
+            $renderer->setCompact($this->showFullscreen || $this->view->compact);
+
             $this->renderer = $renderer;
         }
 

--- a/library/Businessprocess/BpConfig.php
+++ b/library/Businessprocess/BpConfig.php
@@ -88,6 +88,13 @@ class BpConfig
      */
     protected $hosts = array();
 
+    /**
+     * All host groups { 'hostgroupA' => true, ... }
+     *
+     * @var array
+     */
+    protected $hostgroups = array();
+
     /** @var bool Whether catchable errors should be thrown nonetheless */
     protected $throwErrors = false;
 
@@ -416,6 +423,16 @@ class BpConfig
         return $node;
     }
 
+    public function createHostgroup($hostgroup)
+    {
+        $node = new HostGroupnode($this, (object) array(
+            'name' => $hostgroup,
+        ));
+        $this->nodes['HOSTGROUP;' . $hostgroup] = $node;
+        $this->hostgroups[$hostgroup] = true;
+        return $node;
+    }
+
     public function calculateAllStates()
     {
         foreach ($this->getRootNodes() as $node) {
@@ -437,6 +454,11 @@ class BpConfig
     public function listInvolvedHostNames()
     {
         return array_keys($this->hosts);
+    }
+
+    public function listInvolvedHostGroups()
+    {
+        return array_keys($this->hostgroups);
     }
 
     /**
@@ -505,13 +527,14 @@ class BpConfig
         $this->warn(sprintf('The node "%s" doesn\'t exist', $name));
         $pos = strpos($name, ';');
         if ($pos !== false) {
-            $host = substr($name, 0, $pos);
-            $service = substr($name, $pos + 1);
-            // TODO: deactivated, this scares me, test it
-            if ($service === 'Hoststatus') {
-                return $this->createHost($host);
+            $a = substr($name, 0, $pos);
+            $b = substr($name, $pos + 1);
+            if ($a === 'HOSTGROUP') {
+                return $this->createHostgroup($b);
+            } elseif ($b === 'Hoststatus') {
+                return $this->createHost($a);
             } else {
-                return $this->createService($host, $service);
+                return $this->createService($a, $b);
             }
         }
 

--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -22,21 +22,9 @@ class BpNode extends Node
     /** @var array */
     protected $childNames = array();
     protected $alias;
-    protected $counters;
     protected $missing = null;
     protected $missingChildren;
-
-    protected static $emptyStateSummary = array(
-        'OK'          => 0,
-        'WARNING'     => 0,
-        'CRITICAL'    => 0,
-        'UNKNOWN'     => 0,
-        'PENDING'     => 0,
-        'UP'          => 0,
-        'DOWN'        => 0,
-        'UNREACHABLE' => 0,
-        'MISSING'     => 0,
-    );
+    protected $stateSummary = true;
 
     protected static $sortStateInversionMap = array(
         4 => 0,
@@ -54,49 +42,6 @@ class BpNode extends Node
         $this->name = $object->name;
         $this->setOperator($object->operator);
         $this->setChildNames($object->child_names);
-    }
-
-    public function getStateSummary()
-    {
-        if ($this->counters === null) {
-            $this->getState();
-            $this->counters = self::$emptyStateSummary;
-
-            foreach ($this->getChildren() as $child) {
-                if ($child instanceof BpNode) {
-                    $counters = $child->getStateSummary();
-                    foreach ($counters as $k => $v) {
-                        $this->counters[$k] += $v;
-                    }
-                } elseif ($child->isMissing()) {
-                    $this->counters['MISSING']++;
-                } else {
-                    $state = $child->getStateName();
-                    $this->counters[$state]++;
-                }
-            }
-            if (! $this->hasChildren()) {
-                $this->counters['MISSING']++;
-            }
-        }
-        return $this->counters;
-    }
-
-    public function hasProblems()
-    {
-        if ($this->isProblem()) {
-            return true;
-        }
-
-        $okStates = array('OK', 'UP', 'PENDING', 'MISSING');
-
-        foreach ($this->getStateSummary() as $state => $cnt) {
-            if ($cnt !== 0 && ! in_array($state, $okStates)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -121,21 +66,6 @@ class BpNode extends Node
         $this->childNames[] = $name;
         $node->addParent($this);
         return $this;
-    }
-
-    public function getProblematicChildren()
-    {
-        $problems = array();
-
-        foreach ($this->getChildren() as $child) {
-            if ($child->isProblem()
-                || ($child instanceof BpNode && $child->hasProblems())
-            ) {
-                $problems[] = $child;
-            }
-        }
-
-        return $problems;
     }
 
     public function hasChild($name)

--- a/library/Businessprocess/HostGroupnode.php
+++ b/library/Businessprocess/HostGroupnode.php
@@ -20,7 +20,9 @@ class HostGroupnode extends MonitoredNode
         if (isset($object->state)) {
             $this->setState($object->state);
         } else {
-            $this->setState(0)->setMissing();
+            $this->setState(3)->setMissing();
+            $this->counters = static::$emptyStateSummary;
+            $this->counters['MISSING'] = 1;
         }
     }
 

--- a/library/Businessprocess/HostGroupnode.php
+++ b/library/Businessprocess/HostGroupnode.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Icinga\Module\Businessprocess;
+
+use Icinga\Module\Businessprocess\Web\Url;
+
+class HostGroupnode extends MonitoredNode
+{
+    protected $className = 'hostgroup';
+
+    protected $hostgroup_name;
+
+    public function __construct(BpConfig $bp, $object)
+    {
+        $this->name = 'HOSTGROUP;' . $object->name;
+        $this->hostgroup_name = $object->name;
+        $this->bp = $bp;
+        if (isset($object->state)) {
+            $this->setState($object->state);
+        } else {
+            $this->setState(0)->setMissing();
+        }
+    }
+
+    public function getAlias()
+    {
+        return $this->getHostgroupName();
+    }
+
+    public function getHostgroupName()
+    {
+        return $this->hostgroup_name;
+    }
+
+    public function getUrl()
+    {
+        $params = array(
+            'hostgroup' => $this->getHostgroupName(),
+            'sort'      => 'service_severity',
+            'dir'       => 'desc',
+        );
+
+        if ($this->bp->hasBackendName()) {
+            $params['backend'] = $this->bp->getBackendName();
+        }
+
+        return Url::fromPath('monitoring/list/services', $params);
+    }
+}

--- a/library/Businessprocess/HostGroupnode.php
+++ b/library/Businessprocess/HostGroupnode.php
@@ -8,6 +8,8 @@ class HostGroupnode extends MonitoredNode
 {
     protected $className = 'hostgroup';
 
+    protected $stateSummary = true;
+
     protected $hostgroup_name;
 
     public function __construct(BpConfig $bp, $object)
@@ -45,5 +47,11 @@ class HostGroupnode extends MonitoredNode
         }
 
         return Url::fromPath('monitoring/list/services', $params);
+    }
+
+    public function setCounters($counters)
+    {
+        $this->counters = $counters;
+        return $this;
     }
 }

--- a/library/Businessprocess/Ido/BpHostgroupsummaryQuery.php
+++ b/library/Businessprocess/Ido/BpHostgroupsummaryQuery.php
@@ -1,0 +1,76 @@
+<?php
+/* Icinga Web 2 | (c) 2015 Icinga Development Team | GPLv2+ */
+
+namespace Icinga\Module\Businessprocess\Ido;
+
+use Icinga\Exception\InvalidPropertyException;
+use Icinga\Module\Monitoring\Backend\Ido\Query\HostgroupsummaryQuery;
+use Zend_Db_Expr;
+use Zend_Db_Select;
+
+/**
+ * Query for host group summary
+ */
+class BpHostgroupsummaryQuery extends HostgroupsummaryQuery
+{
+    protected $stateTypeMap = array(
+        'hard' => 'hard_state',
+        'soft' => 'state',
+    );
+
+    protected $stateType = 'soft';
+
+    public function setStateType($type)
+    {
+        if (! array_key_exists($type, $this->stateTypeMap)) {
+            throw new InvalidPropertyException(
+                'type must be one of: ' . join(', ', array_keys($this->stateTypeMap))
+            );
+        }
+        $this->stateType = $type;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function joinBaseTables()
+    {
+        $stateTypeSuffix = $this->stateTypeMap[$this->stateType];
+
+        $hosts = $this->createSubQuery(
+            'Hoststatus',
+            array(
+                'handled'       => 'host_handled',
+                'host_state'    => new Zend_Db_Expr('NULL'),
+                'hostgroup_alias',
+                'hostgroup_name',
+                'object_type',
+                'severity'      => 'host_severity',
+                'state'         => 'host_' . $stateTypeSuffix,
+                'state_change'  => 'host_last_' . $stateTypeSuffix . '_change'
+            )
+        );
+        $hosts->select()->where('hgo.name1 IS NOT NULL'); // TODO(9458): Should be possible using our filters!
+        $this->subQueries[] = $hosts;
+        $services = $this->createSubQuery(
+            'Servicestatus',
+            array(
+                'handled'       => 'service_handled',
+                'host_state'    => 'host_hard_state', // TODO: why?
+                'hostgroup_alias',
+                'hostgroup_name',
+                'object_type',
+                'severity'      => new Zend_Db_Expr('NULL'),
+                'state'         => 'service_' . $stateTypeSuffix,
+                'state_change'  => 'service_last_' . $stateTypeSuffix . '_change'
+            )
+        );
+        $services->select()->where('hgo.name1 IS NOT NULL'); // TODO(9458): Should be possible using our filters!
+        $this->subQueries[] = $services;
+        $this->summaryQuery = $this->db->select()->union(array($hosts, $services), Zend_Db_Select::SQL_UNION_ALL);
+        $this->select->from(array('statussummary' => $this->summaryQuery), array());
+        $this->group(array('statussummary.hostgroup_name', 'statussummary.hostgroup_alias'));
+        $this->joinedVirtualTables['hoststatussummary'] = true;
+    }
+}

--- a/library/Businessprocess/Renderer/Renderer.php
+++ b/library/Businessprocess/Renderer/Renderer.php
@@ -36,6 +36,9 @@ abstract class Renderer extends Html
     /** @var bool */
     protected $isBreadcrumb = false;
 
+    /** @var bool */
+    protected $isCompact = false;
+
     /**
      * Renderer constructor.
      *
@@ -310,6 +313,17 @@ abstract class Renderer extends Html
     protected function createUnboundParent(BpConfig $bp)
     {
         return $bp->getNode('__unbound__');
+    }
+
+    public function setCompact($compact)
+    {
+        $this->isCompact = (bool) $compact;
+        return $this;
+    }
+
+    public function isCompact()
+    {
+        return $this->isCompact;
     }
 
     /**

--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -88,12 +88,12 @@ class NodeTile extends BaseElement
             }
         }
 
-        if (! $renderer->isBreadcrumb()) {
+        if (! $renderer->isBreadcrumb() && ! $this->renderer->isCompact()) {
             $this->addDetailsActions();
-        }
 
-        if (! $renderer->isLocked()) {
-            $this->addActionLinks();
+            if (! $renderer->isLocked()) {
+                $this->addActionLinks();
+            }
         }
 
         return parent::render();

--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -6,7 +6,6 @@ use Icinga\Module\Businessprocess\BpNode;
 use Icinga\Module\Businessprocess\HostNode;
 use Icinga\Module\Businessprocess\Html\BaseElement;
 use Icinga\Module\Businessprocess\Html\Container;
-use Icinga\Module\Businessprocess\Html\HtmlString;
 use Icinga\Module\Businessprocess\Html\Icon;
 use Icinga\Module\Businessprocess\Html\Link;
 use Icinga\Module\Businessprocess\ImportedNode;
@@ -81,7 +80,7 @@ class NodeTile extends BaseElement
         $link = $this->getMainNodeLink();
         $this->add($link);
 
-        if ($node instanceof BpNode) {
+        if ($node->hasStateSummary()) {
             if ($renderer->isBreadcrumb()) {
                 $link->addContent($renderer->renderStateBadges($node->getStateSummary()));
             } else {
@@ -174,16 +173,16 @@ class NodeTile extends BaseElement
     {
         $node = $this->node;
         $url = $this->getMainNodeUrl($node);
-        if ($node instanceof ServiceNode) {
+        if ($node instanceof HostNode) {
             $link = Link::create(
-                $node->getAlias(),
+                $node->getHostname(),
                 $url,
                 null,
                 array('data-base-target' => '_next')
             );
-        } elseif ($node instanceof HostNode) {
+        } elseif ($node instanceof MonitoredNode) {
             $link = Link::create(
-                $node->getHostname(),
+                $node->getAlias(),
                 $url,
                 null,
                 array('data-base-target' => '_next')

--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -151,7 +151,7 @@ class TreeRenderer extends Renderer
         $link->attributes()->set('data-base-target', '_next');
         $link->addContent($this->getNodeIcons($node));
 
-        if ($node->hasChildren()) {
+        if ($node->hasStateSummary()) {
             $link->addContent($this->renderStateBadges($node->getStateSummary()));
         }
 

--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -123,6 +123,10 @@ class TreeRenderer extends Renderer
             $attributes->add('class', 'node');
         }
 
+        if (count($path) > 0) {
+            $attributes->add('class', 'collapsed');
+        }
+
         $tbody = $table->createElement('tbody');
         $tr =  $tbody->createElement('tr');
 

--- a/library/Businessprocess/Storage/LegacyConfigParser.php
+++ b/library/Businessprocess/Storage/LegacyConfigParser.php
@@ -308,11 +308,13 @@ class LegacyConfigParser
                     continue;
                 }
 
-                list($host, $service) = preg_split('~;~', $val, 2);
-                if ($service === 'Hoststatus') {
-                    $bp->createHost($host);
+                list($a, $b) = preg_split('~;~', $val, 2);
+                if ($a === 'HOSTGROUP') {
+                    $bp->createHostgroup($b);
+                } else if ($b === 'Hoststatus') {
+                    $bp->createHost($a);
                 } else {
-                    $bp->createService($host, $service);
+                    $bp->createService($a, $b);
                 }
             }
             if ($val[0] === '@') {

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -404,9 +404,9 @@ div.bp .badges {
 
 .badge-critical, .badge-down { background: @colorCritical; }
 .badge-unknown, .badge-unreachable { background: @colorUnknown; }
-.badge-warning { background: @colorWarning; }
-.badge-pending { background: @colorPending; }
-.badge-missing { background: #ccc; }
+.badge-warning { background: @colorWarning; color: #6d572b; }
+.badge-pending { background: @colorPending; color: #32486d; }
+.badge-missing { background: #ccc; color: #32486d; }
 /** END Badges **/
 
 /** BEGIN Tiles **/
@@ -426,11 +426,28 @@ div.bp .badges {
     margin-bottom: 0.2em;
     height: 6em;
     cursor: pointer;
+    position: relative;
 
     .badges {
+        display: block;
+        position: absolute;
+        top: 0.3em;
+        right: 0.3em;
+
         text-align: center;
         font-size: 0.5em;
-        display: block;
+
+        // background: white;
+        padding: 0;
+        //border-radius: 0.3em;
+        //border: none;
+
+        opacity: 0.8;
+
+        .badge {
+            margin: 0;
+            border-width: 2px;
+        }
     }
 
     > a {
@@ -446,6 +463,7 @@ div.bp .badges {
         margin-left: 0.5em;
         padding-top: 0.2em;
         height: 1.8em;
+        color: white;
 
         i {
             float: none;
@@ -463,11 +481,13 @@ div.bp .badges {
             width: 1.5em;
             height: 1.5em;
             border-radius: 0.3em;
+            opacity: 0.6;
         }
 
         a:hover {
             background-color: white;
             color: @text-color;
+            opacity: 0.9;
         }
     }
 }
@@ -486,7 +506,7 @@ div.bp .badges {
 
 .tiles > div > a {
     text-decoration: none;
-    font-size: 0.5em;
+    font-size: 0.6em;
     color: inherit;
     vertical-align: middle;
     text-align: center;
@@ -498,20 +518,20 @@ div.bp .badges {
 }
 
 .tiles {
-    > .critical            { background-color: @colorCritical; background-color: @colorCritical; color: white; }
-    > .critical.handled    { background-color: @colorCriticalHandled; }
-    > .down                { background-color: @colorCritical; }
-    > .down.handled        { background-color: @colorCriticalHandled; }
-    > .unknown             { background-color: @colorUnknown; }
-    > .unknown.handled     { background-color: @colorUnknownHandled; }
-    > .unreachable         { background-color: @colorUnknown; }
-    > .unreachable.handled { background-color: @colorUnknownHandled; }
-    > .warning             { background-color: @colorWarning; }
-    > .warning.handled     { background-color: @colorWarningHandled; }
-    > .ok                  { background-color: @colorOk; }
-    > .up                  { background-color: @colorOk; }
-    > .pending             { background-color: @colorPending; }
-    > .missing             { background-color: #ccc; }
+    > .critical            { background-color: @colorCritical;        color: white; }
+    > .critical.handled    { background-color: @colorCriticalHandled; color: #6d4148; }
+    > .down                { background-color: @colorCritical;        color: white; }
+    > .down.handled        { background-color: @colorCriticalHandled; color: #6d4148; }
+    > .unknown             { background-color: @colorUnknown;         color: white; }
+    > .unknown.handled     { background-color: @colorUnknownHandled;  color: #57326d; }
+    > .unreachable         { background-color: @colorUnknown;         color: white; }
+    > .unreachable.handled { background-color: @colorUnknownHandled;  color: #57326d; }
+    > .warning             { background-color: @colorWarning;         color: #6d572b; }
+    > .warning.handled     { background-color: @colorWarningHandled;  color: #6d572b; }
+    > .ok                  { background-color: @colorOk;              color: white; }
+    > .up                  { background-color: @colorOk;              color: white; }
+    > .pending             { background-color: @colorPending;         color: #32486d; }
+    > .missing             { background-color: #ccc;                  color: #32486d; }
     > .addnew              { background-color: @icinga-blue; }
 }
 

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -178,6 +178,10 @@ table.bp.node.host td:before {
     content: '\e866';
 }
 
+table.bp.node.hostgroup td:before {
+    content: '\e83f';
+}
+
 /* Border defaults */
 table.bp {
     border-width: 0;


### PR DESCRIPTION
**Note:** Still work in progress.

Currently the changes are based on #137 and #139 

The idea is simple. Add a hostgroup as an element, and use the summarized state as part of the process.

## Changes

### Config Format

The config format needs to be extended. My simpliest idea is:

```
process = HOSTGROUP;linux-servers-dc1 & HOSTGROUP;linux-servers-dc2
```

### Node logic

To add the hostgroup, we just add it as a node type, letting the summarized state being display in the webinterface. And not every part.