### PR TITLE
BpNode: Use worst state in minimum state calculation

### DIFF
--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -364,13 +364,23 @@ class BpNode extends Node
                 break;
             default:
                 // MIN:
-                sort($sort_states);
-
-                // default -> unknown
                 $sort_state = 3 << self::SHIFT_FLAGS;
 
-                for ($i = 1; $i <= $this->operator; $i++) {
-                    $sort_state = array_shift($sort_states);
+                if (count($sort_states) >= $this->operator) {
+                    $actualGood = 0;
+                    foreach ($sort_states as $s) {
+                        if (($s >> self::SHIFT_FLAGS) === self::ICINGA_OK) {
+                            $actualGood++;
+                        }
+                    }
+
+                    if ($actualGood >= $this->operator) {
+                        // condition is fulfilled
+                        $sort_state = self::ICINGA_OK;
+                    } else {
+                        // worst state if not fulfilled
+                        $sort_state = max($sort_states);
+                    }
                 }
         }
         if ($sort_state & self::FLAG_DOWNTIME) {

--- a/test/php/library/Businessprocess/Operators/MinOperatorTest.php
+++ b/test/php/library/Businessprocess/Operators/MinOperatorTest.php
@@ -49,7 +49,7 @@ class MinOperatorTest extends BaseTestCase
         );
     }
 
-    public function testTwoOfCriticalAndWarningAndOkAreAtLeastWarning()
+    public function testTwoOfCriticalAndWarningAndOkAreAtLeastCritical()
     {
         $bp = $this->getBp();
         $bp->setNodeState('b', 2);
@@ -57,12 +57,12 @@ class MinOperatorTest extends BaseTestCase
         $bp->setNodeState('d', 0);
 
         $this->assertEquals(
-            'WARNING',
+            'CRITICAL',
             $bp->getNode('a')->getStateName()
         );
     }
 
-    public function testTwoOfUnknownAndWarningAndCriticalAreAtLeastUnknown()
+    public function testTwoOfUnknownAndWarningAndCriticalAreAtLeastCritical()
     {
         $bp = $this->getBp();
         $bp->setNodeState('b', 2);
@@ -70,20 +70,20 @@ class MinOperatorTest extends BaseTestCase
         $bp->setNodeState('d', 3);
 
         $this->assertEquals(
-            'UNKNOWN',
+            'CRITICAL',
             $bp->getNode('a')->getStateName()
         );
     }
 
-    public function testTwoOfTwoTimesWarningAndUnknownAreAtLeastWarning()
+    public function testTwoOfTwoTimesWarningAndUnknownAreAtLeastUnknown()
     {
         $bp = $this->getBp();
-        $bp->setNodeState('b', 0);
+        $bp->setNodeState('b', 3);
         $bp->setNodeState('c', 1);
         $bp->setNodeState('d', 1);
 
         $this->assertEquals(
-            'WARNING',
+            'UNKNOWN',
             $bp->getNode('a')->getStateName()
         );
     }
@@ -101,17 +101,74 @@ class MinOperatorTest extends BaseTestCase
         );
     }
 
+    public function testTenWithAllOk()
+    {
+        $bp = $this->getBp(10, 9, 0);
+
+        $this->assertEquals(
+            'OK',
+            $bp->getNode('a')->getStateName()
+        );
+    }
+
+    public function testTenWithOnlyTwoCritical()
+    {
+        $bp = $this->getBp(10, 8, 0);
+        $bp->setNodeState('b', 2);
+        $bp->setNodeState('c', 2);
+
+        $this->assertEquals(
+            'OK',
+            $bp->getNode('a')->getStateName()
+        );
+    }
+
+    public function testTenWithThreeCritical()
+    {
+        $bp = $this->getBp(10, 8, 0);
+        $bp->setNodeState('b', 2);
+        $bp->setNodeState('c', 2);
+        $bp->setNodeState('d', 2);
+
+        $this->assertEquals(
+            'CRITICAL',
+            $bp->getNode('a')->getStateName()
+        );
+    }
+
+    public function testTenWithThreeWarning()
+    {
+        $bp = $this->getBp(10, 8, 0);
+        $bp->setNodeState('b', 1);
+        $bp->setNodeState('c', 1);
+        $bp->setNodeState('d', 1);
+
+        $this->assertEquals(
+            'WARNING',
+            $bp->getNode('a')->getStateName()
+        );
+    }
+
     /**
      * @return BpConfig
      */
-    protected function getBp()
+    protected function getBp($count = 3, $min = 2, $defaultState = null)
     {
+        $names = array();
+        $a = 97;
+        for ($i = 1; $i <= $count; $i++) {
+            $names[] = chr($a + $i);
+        }
+
         $storage = new LegacyStorage($this->emptyConfigSection());
-        $expression = 'a = 2 of: b + c + d';
+        $expression = sprintf('a = %d of: %s', $min, join(' + ', $names));
         $bp = $storage->loadFromString('dummy', $expression);
-        $bp->createBp('b');
-        $bp->createBp('c');
-        $bp->createBp('d');
+        foreach ($names as $n) {
+            $bp->createBp($n);
+            if ($defaultState !== null) {
+                $bp->setNodeState($n, $defaultState);
+            }
+        }
 
         return $bp;
     }


### PR DESCRIPTION
Ensure we use the worst state within a minimum condition, previously we
did use the Xth best state only...

- [x] Update unit tests

fixes #167 