### PR TITLE
Fix misspelled delete / cancel icon name.

### DIFF
--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -331,7 +331,7 @@ class NodeTile extends BaseHtmlElement
                 'href'  => $renderer->getUrl()->with($params),
                 'title' => mt('businessprocess', 'Delete this node')
             ],
-            Html::tag('i', ['class' => 'icon icon-cancle'])
+            Html::tag('i', ['class' => 'icon icon-cancel'])
         ));
     }
 }


### PR DESCRIPTION
Noticed missing delete option.

After a bit of digging I found the option but it was invisible as the icon was misspelled.