### PR TITLE
Fix: Editing of BP-Nodes shows content of previous node in edit form

### DIFF
--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -265,7 +265,8 @@ class TreeRenderer extends Renderer
             'edit',
             $this->getUrl()->with(array(
                 'action'   => 'edit',
-                'editnode' => $node->getName()
+                'editnode' => $node->getName(),
+                'node'     => $node->getName()
             )),
             mt('businessprocess', 'Modify this node')
         );


### PR DESCRIPTION
Hi,

we found this issue during a training: 
If you show your BP in tree-view & edit a node, it'll show the name & content of the previous node.

This is my BP:
![bp](https://user-images.githubusercontent.com/1445753/73949063-2c458980-48fa-11ea-99dc-201b27d00bd4.png)

Clicking "Modify this Node" on Node "PostgreSQL" shows node-name and content of the "Apache"-Node:
![bad_bp](https://user-images.githubusercontent.com/1445753/73949062-2bacf300-48fa-11ea-83cf-c56c46d3c141.png)

After this commit it looks like this:
![correct_bp](https://user-images.githubusercontent.com/1445753/73949064-2cde2000-48fa-11ea-8596-26a6bf49d090.png)

hope this is correct. 
regards, nold
