### PR TITLE
Add animations for breadcrumbs on impact

### DIFF
--- a/public/css/module.less
+++ b/public/css/module.less
@@ -676,6 +676,10 @@ td > a > .badges {
         .transition(border-color 2s 1s linear !important);
         border-color: @gray-light !important;
     }
+    .breadcrumb li:not(:last-of-type) a:hover {
+        background-color: transparent !important;
+        color: @icinga-blue;
+    }
 }
 
 .tabs > .dropdown-nav-item > ul {
@@ -688,8 +692,8 @@ td > a > .badges {
 }
 
 .breadcrumb li:not(:last-child) a:hover { background: @icinga-blue; color: white; }
-.breadcrumb li:not(:last-child) a:hover:after { border-left-color: @icinga-blue !important; }
-.breadcrumb li:last-child:hover, .breadcrumb li:last-child a:hover { background: @icinga-blue; border-color: @icinga-blue !important; }
+.breadcrumb li:not(:last-child) a:hover:after { border-left-color: @icinga-blue; }
+.breadcrumb li:last-child:hover, .breadcrumb li:last-child a:hover { background: @icinga-blue; border-color: @icinga-blue; }
 
 .breadcrumb li a:focus {
     text-decoration: underline;

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -661,6 +661,23 @@ td > a > .badges {
     z-index: 2;
 }
 
+&.impact {
+    .breadcrumb li:not(:last-of-type) a:after {
+        .transition(border-left-color 2s 1s linear !important);
+        border-left-color: @gray-lighter !important;
+    }
+
+    .breadcrumb li:not(:last-of-type) a:before {
+        .transition(border-left-color 2s 1s linear !important);
+        border-left-color: @gray-light !important;
+    }
+
+    .breadcrumb li:not(:last-of-type) {
+        .transition(border-color 2s 1s linear !important);
+        border-color: @gray-light !important;
+    }
+}
+
 .tabs > .dropdown-nav-item > ul {
     z-index: 100;
 }

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -663,7 +663,7 @@ td > a > .badges {
 
 &.impact {
     .breadcrumb li:not(:last-of-type) a:after {
-        .transition(border-left-color 2s 1s linear !important);
+        .transition(border-left-color 2s 0.66s linear !important);
         border-left-color: @gray-lighter !important;
     }
 


### PR DESCRIPTION
refs #242

Animations are still a bit laggy - animation for the `:after` triangles start after the `<li>`s animations are through.