### PR TITLE
Fix 'vsprintf(): Too few arguments' in ProcessController::showAction()

### DIFF
--- a/application/controllers/ProcessController.php
+++ b/application/controllers/ProcessController.php
@@ -110,7 +110,7 @@ class ProcessController extends Controller
                 $missing = array_slice($missing, 0, 10);
                 $missing[] = '...';
             }
-            $bp->addError(sprintf('There are %d missing nodes: %s', $count, implode(', ', $missing)));
+            $bp->addError('There are %d missing nodes: %s', $count, implode(', ', $missing));
         }
         $this->content()->add($this->showHints($bp));
         $this->content()->add($this->showWarnings($bp));

--- a/library/Businessprocess/BpConfig.php
+++ b/library/Businessprocess/BpConfig.php
@@ -915,7 +915,9 @@ class BpConfig
     {
         $args = func_get_args();
         array_shift($args);
-        $msg = vsprintf($msg, $args);
+        if (! empty($args)) {
+            $msg = vsprintf($msg, $args);
+        }
         if ($this->throwErrors) {
             throw new IcingaException($msg);
         }


### PR DESCRIPTION
Before, we called printf twice because BpConfig::addError()
already makes use of printf. The exception only occured for
nodes that have a percent sign (%) in their name.

fixes #234