### PR TITLE
Fix superfluous base target overrides

### DIFF
--- a/library/Businessprocess/Renderer/TileRenderer.php
+++ b/library/Businessprocess/Renderer/TileRenderer.php
@@ -19,7 +19,7 @@ class TileRenderer extends Renderer
             'div',
             [
                 'class'                         => ['sortable', 'tiles', $this->howMany()],
-                'data-base-target'              => '_next',
+                'data-base-target'              => '_self',
                 'data-sortable-disabled'        => $this->isLocked() ? 'true' : 'false',
                 'data-sortable-data-id-attr'    => 'id',
                 'data-sortable-direction'       => 'horizontal', // Otherwise movement is buggy on small lists

--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -59,8 +59,7 @@ class NodeTile extends BaseHtmlElement
         $this->actions = Html::tag(
             'div',
             [
-                'class'            => 'actions',
-                'data-base-target' => '_self'
+                'class' => 'actions'
             ]
         );
 
@@ -166,7 +165,6 @@ class NodeTile extends BaseHtmlElement
             $link = Html::tag('a', ['href' => $url, 'data-base-target' => '_next'], $node->getAlias());
         } else {
             $link = Html::tag('a', ['href' => $url], $node->getAlias());
-            $link->getAttributes()->add('data-base-target', '_self');
         }
 
         return $link;
@@ -181,7 +179,6 @@ class NodeTile extends BaseHtmlElement
             $this->actions()->add(Html::tag(
                 'a',
                 [
-                    'data-base-target' => '_self',
                     'href'  => $url->with('mode', 'tile'),
                     'title' => mt('businessprocess', 'Show tiles for this subtree')
                 ],
@@ -189,7 +186,6 @@ class NodeTile extends BaseHtmlElement
             ))->add(Html::tag(
                 'a',
                 [
-                    'data-base-target' => '_next',
                     'href'  => $url->with('mode', 'tree'),
                     'title' => mt('businessprocess', 'Show this subtree as a tree')
                 ],


### PR DESCRIPTION
* Fix drill down of the tile/tree action icon links
* Set base target only on parent containers

This also fixes the dashboard integration where we only override the
base target of the div.tiles containers.

fixes #243