### PR TITLE
Fix tile rendering for Bp nodes with unconfirmed deleted monitored nodes

### DIFF
--- a/library/Businessprocess/Modification/NodeRemoveAction.php
+++ b/library/Businessprocess/Modification/NodeRemoveAction.php
@@ -62,7 +62,6 @@ class NodeRemoveAction extends NodeAction
      */
     public function applyTo(BpConfig $config)
     {
-        $config->calculateAllStates();
         $name = $this->getNodeName();
         $parentName = $this->getParentName();
         if ($parentName === null) {
@@ -81,7 +80,6 @@ class NodeRemoveAction extends NodeAction
         } else {
             $node = $config->getNode($name);
             $parent = $config->getBpNode($parentName);
-            $parent->getState();
             $parent->removeChild($name);
             $node->removeParent($parentName);
             if (! $node->hasParents()) {


### PR DESCRIPTION
Earlier in NodeRemoveAction the states were recalculated for the BpNodes. Hence, the state for parent nodes with unconfirmed deleted monitored nodes (host/service) is set to Unknown. This results in incorrect tile rendering for the parent nodes. Therefore, any call to methods which recalculate the states are removed.

fix #279

Before: 
![image](https://user-images.githubusercontent.com/33730024/82343732-7e1aa700-99f3-11ea-9b39-ae183ea5814d.png)

After:
![image](https://user-images.githubusercontent.com/33730024/82343836-9c80a280-99f3-11ea-8949-7ab242fc62c8.png)
