### PR TITLE
Fix rendering of state-balls for critical-handled nodes

### DIFF
--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -88,10 +88,14 @@ class NodeTile extends BaseHtmlElement
         if (! $node instanceof ImportedNode || $node->getBpConfig()->hasNode($node->getName())) {
             $link = $this->getMainNodeLink();
             if ($renderer->isBreadcrumb()) {
-                $link->prepend((new StateBall(strtolower($node->getStateName())))->addAttributes([
+                $state = strtolower($node->getStateName());
+                if ($node->isHandled()) {
+                    $state = $state . '-handled';
+                }
+                $link->prepend((new StateBall($state))->addAttributes([
                     'title' => sprintf(
                         '%s %s',
-                        $node->getStateName(),
+                        $state,
                         DateFormatter::timeSince($node->getLastStateChange())
                     )
                 ]));

--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -116,10 +116,14 @@ class TreeRenderer extends Renderer
         } else {
             $icons[] = $node->getIcon();
         }
-        $icons[] = (new StateBall(strtolower($node->getStateName())))->addAttributes([
+        $state = strtolower($node->getStateName());
+        if ($node->isHandled()) {
+            $state = $state . '-handled';
+        }
+        $icons[] = (new StateBall($state))->addAttributes([
             'title' => sprintf(
                 '%s %s',
-                $node->getStateName(),
+                $state,
                 DateFormatter::timeSince($node->getLastStateChange())
             )
         ]);

--- a/public/css/state-ball.less
+++ b/public/css/state-ball.less
@@ -30,6 +30,14 @@
     background-color: @gray-light;
   }
 
+  &.state-critical-handled {
+    background-color: @color-critical-handled;
+  }
+
+  &.state-down-handled {
+    background-color: @color-critical-handled;
+  }
+
   &.size-xs {
     line-height: 0.75em;
     height: 0.75em;


### PR DESCRIPTION
The state-balls for critical-handled nodes (nodes that are critical/down and have been acknowledged or a downtime is scheduled) are incorrectly rendered. 

This has been fixed in this pull request, by introducing new state-balls for critical-handled nodes and using these state-balls to render them.

## Before fix
![Screenshot 2020-05-25 at 12 02 01](https://user-images.githubusercontent.com/33730024/82804673-f9140f80-9e82-11ea-8155-aabdd694eda2.png)

![Screenshot 2020-05-25 at 12 04 03](https://user-images.githubusercontent.com/33730024/82804639-ea2d5d00-9e82-11ea-9f59-2148005ee2fe.png)

## After fix
![Screenshot 2020-05-25 at 12 00 34](https://user-images.githubusercontent.com/33730024/82804726-19dc6500-9e83-11ea-93b6-8886f1417045.png)

![Screenshot 2020-05-25 at 11 56 37](https://user-images.githubusercontent.com/33730024/82804760-2791ea80-9e83-11ea-9a7d-e4f4181e28ec.png)
