### PR TITLE
Fix newline issue of screenshots of docs/about page

### DIFF
--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -4,9 +4,7 @@ If you want to visualize and monitor hierarchical business processes based on
 any or all objects monitored by Icinga, the Icinga Web 2 business process
 module is the way to go.
 
-[![Tile View](screenshot/00_preview/0005_preview-smaller-tile-view.png)](doc/13-Web-Components-Tile-Renderer.md)
-[![Tree View](screenshot/00_preview/0006_preview-smaller-tree-view.png)](doc/14-Web-Components-Tree-Renderer.md)
-[![Dashboard](screenshot/00_preview/0007_preview-smallerbusinessprocesses-on-dashboard.png)](doc/16-Add-To-Dashboard.md)
+[![Dashboard](screenshot/16_dashboard/1603_businessprocesses_on_dashboard.png)](doc/16-Add-To-Dashboard.md)
 
 Want to create custom process-based dashboards? Trigger notifications at
 process or sub-process level? Provide a quick top-level view for thousands of


### PR DESCRIPTION
Adding multiple screenshots works on GitHub but is not suitable
for the rendered version of the docs. The images are too small
and newlines are added because of lacking space.

I changed that by including a single dashboard image.