### PR TITLE
Permissions: add form elements and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Documentation
 * [Customize Node Order](doc/06-Customize-Node-Order.md)
 * [State Overrides](doc/07-State-Overrides.md)
 * [Operators](doc/09-Operators.md)
+* [Controlling Access](doc/31-Permissions.md)
 
 ### Web Components
 * [Breadcrumb](doc/12-Web-Components-Breadcrumb.md)

--- a/application/forms/BpConfigForm.php
+++ b/application/forms/BpConfigForm.php
@@ -88,6 +88,27 @@ class BpConfigForm extends BpConfigBaseForm
             )
         ));
 
+        $this->addElement('text', 'AllowedUsers', array(
+            'label'       => $this->translate('Allowed Users'),
+            'description' => $this->translate(
+                'Allowed Users (comma-separated)'
+            ),
+        ));
+
+        $this->addElement('text', 'AllowedGroups', array(
+            'label'       => $this->translate('Allowed Groups'),
+            'description' => $this->translate(
+                'Allowed Groups (comma-separated)'
+            ),
+        ));
+
+        $this->addElement('text', 'AllowedRoles', array(
+            'label'       => $this->translate('Allowed Roles'),
+            'description' => $this->translate(
+                'Allowed Roles (comma-separated)'
+            ),
+        ));
+
         if ($this->config === null) {
             $this->setSubmitLabel(
                 $this->translate('Add')

--- a/doc/31-Permissions.md
+++ b/doc/31-Permissions.md
@@ -1,0 +1,28 @@
+<a id="Permission System"></a>Permission System
+=================================================
+
+The permission system of the module is based on permissions and restrictions.
+
+Permissions
+-----------
+
+The module has five levels of permissions:
+
+* Granting general module access allows a user to view business processes. (`module/businessprocess`)
+* Create permissions allow to create new business processes. (`businessprocess/create`)
+* Modify permissions allow to modify already existing ones. (`businessprocess/modify`)
+* Permission to view all business processes regardless restrictions. (`businessprocess/showall`)
+* Full permissions. (`businessprocess/*`)
+
+Restrictions
+-----------
+
+There are two ways to configure restrictions: prefix-based and access controls
+
+### Prefix-based
+
+This option allows to limit access of a role to only business processes with a specific prefix. For this the ID (Configuration name) of a business process has to start with a prefix and it has to be set as restriction on the role. (`businessprocess/prefix`)
+
+### Access controls
+
+This option allows for more fine granular permissions based on user (`AllowedUsers`), group (`AllowedGroups`) and role (`AllowedRoles`). These attributes take a comma-separated list, get added to the header of the business process configuration file and limit access to the owner and the mentioned ones.


### PR DESCRIPTION
This pull request adds some basic form elements for the access controls and documentation for the permissions and restrictions to move the issues forward.

I have not marked this as fix because the elements are to simple as a real solution in my eyes. They should better have some select option to prevent typos and I recognized that removing the field value will reset the configuration, but already existing fields like the description behave the same way.

resolves #98 
resolves #124