### PR TITLE
Add a nice dashboard for kiosk mode

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -4,6 +4,7 @@ namespace Icinga\Module\Businessprocess\Controllers;
 
 use Icinga\Module\Businessprocess\Web\Controller;
 use Icinga\Module\Businessprocess\Web\Component\Dashboard;
+use Icinga\Module\Businessprocess\Web\Component\DashboardFullscreen;
 
 class IndexController extends Controller
 {
@@ -13,8 +14,16 @@ class IndexController extends Controller
     public function indexAction()
     {
         $this->setTitle($this->translate('Business Process Overview'));
-        $this->controls()->add($this->overviewTab());
-        $this->content()->add(Dashboard::create($this->Auth(), $this->storage()));
-        $this->setAutorefreshInterval(15);
+        if (!$this->showCompact) {
+            $this->controls()->add($this->overviewTab());
+        }
+        if ($this->showFullscreen) {
+            $this->content()->add(DashboardFullscreen::create($this->Auth(), $this->storage()));
+            $this->setAutorefreshInterval(120);
+            $this->controls()->getAttributes()->add('class', 'want-fullscreen');
+        } else {
+            $this->content()->add(Dashboard::create($this->Auth(), $this->storage()));
+            $this->setAutorefreshInterval(15);
+        }
     }
 }

--- a/library/Businessprocess/Web/Component/BpDashboardFullscreenTile.php
+++ b/library/Businessprocess/Web/Component/BpDashboardFullscreenTile.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Icinga\Module\Businessprocess\Web\Component;
+
+use Icinga\Module\Businessprocess\BpConfig;
+use Icinga\Web\Url;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\Html;
+use ipl\Html\Text;
+
+class BpDashboardFullscreenTile extends BaseHtmlElement
+{
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'dashboard-tile dashboard-tile-fullscreen'];
+
+    public function __construct(BpConfig $bp, $title, $description, $icon, $url, $urlParams = null, $attributes = null)
+    {
+        if (! isset($attributes['href'])) {
+            $attributes['href'] = Url::fromPath($url, $urlParams ?: []);
+        }
+
+        $this->add(Html::tag(
+            'div',
+            ['class' => 'bp-link', 'data-base-target' => '_main'],
+            Html::tag('a', $attributes)
+                ->add(Html::tag('span', ['class' => 'header'], $title))
+                ->add($description)
+        ));
+
+        $tiles = Html::tag('div', ['class' => 'bp-root-tiles-fullscreen']);
+
+        foreach ($bp->getChildren() as $node) {
+            $state = strtolower($node->getStateName());
+
+            $tiles->add(Html::tag(
+                'a',
+                [
+                    'href'  => Url::fromPath($url, $urlParams ?: [])->with(['node' => $node->getName()]),
+                    'class' => "badge badge-fullscreen state-{$state}",
+                    'title' => $node->getAlias()
+                ],
+                Text::create($node->getAlias())->setEscaped()
+            ));
+        }
+
+        $this->add($tiles);
+    }
+}

--- a/library/Businessprocess/Web/Component/DashboardFullscreen.php
+++ b/library/Businessprocess/Web/Component/DashboardFullscreen.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Icinga\Module\Businessprocess\Web\Component;
+
+use Icinga\Authentication\Auth;
+use Icinga\Module\Businessprocess\State\MonitoringState;
+use Icinga\Module\Businessprocess\Storage\Storage;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\Html;
+
+class DashboardFullScreen extends BaseHtmlElement
+{
+    /** @var string */
+    protected $contentSeparator = "\n";
+
+    /** @var string */
+    protected $tag = 'div';
+
+    protected $defaultAttributes = array(
+        'class' => 'overview-dashboard',
+        'data-base-target' => '_next'
+    );
+
+    /** @var Auth */
+    protected $auth;
+
+    /** @var Storage */
+    protected $storage;
+
+    /**
+     * Dashboard constructor.
+     * @param Auth $auth
+     * @param Storage $storage
+     */
+    protected function __construct(Auth $auth, Storage $storage)
+    {
+        $this->auth = $auth;
+        $this->storage = $storage;
+        $processes = $storage->listProcessNames();
+        if (empty($processes)) {
+            $this->add(
+                Html::tag('div')
+                    ->add(Html::tag('h1', null, mt('businessprocess', 'Not available')))
+                    ->add(Html::tag('p', null, mt(
+                        'businessprocess',
+                        'No Business Process has been defined for you'
+                    )))
+            );
+        }
+
+        foreach ($processes as $name) {
+            $meta = $storage->loadMetadata($name);
+            $title = $meta->get('Title');
+            if ($title) {
+                $title = sprintf('%s (%s)', $title, $name);
+            } else {
+                $title = $name;
+            }
+
+            $bp = $storage->loadProcess($name);
+            MonitoringState::apply($bp);
+
+            $this->add(new BpDashboardFullscreenTile(
+                $bp,
+                $title,
+                $meta->get('Description'),
+                'sitemap',
+                'businessprocess/process/show',
+                array('config' => $name)
+            ));
+        }
+    }
+
+    /**
+     * @param Auth $auth
+     * @param Storage $storage
+     * @return static
+     */
+    public static function create(Auth $auth, Storage $storage)
+    {
+        return new static($auth, $storage);
+    }
+}

--- a/library/Businessprocess/Web/Controller.php
+++ b/library/Businessprocess/Web/Controller.php
@@ -32,6 +32,9 @@ class Controller extends ModuleController
     private $storage;
 
     /** @var bool */
+    protected $showCompact;
+
+    /** @var bool */
     protected $showFullscreen;
 
     /** @var Url */
@@ -49,8 +52,7 @@ class Controller extends ModuleController
         $this->view->showFullscreen
             = $this->showFullscreen
             = (bool) $this->_helper->layout()->showFullscreen;
-
-        $this->view->compact = $this->params->get('view') === 'compact';
+        $this->showCompact = $this->view->compact;
         $this->setViewScript('default');
     }
 

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -327,6 +327,16 @@ ul.bp {
                 box-shadow: 0px 0px 5px #666;
             }
         }
+
+        .badge-fullscreen {
+            margin: 1px !important;
+            color: #000000;
+        }
+    }
+
+    .dashboard-tile-fullscreen {
+        width: unset !important;
+        max-width: 25%;
     }
 
     .dashboard-tile,
@@ -334,6 +344,11 @@ ul.bp {
         width: 20em;
         display: inline-block;
         vertical-align: top;
+    }
+
+    .bp-root-tiles-fullscreen {
+        display: flex;
+        flex-wrap: wrap;
     }
 
     .action {


### PR DESCRIPTION
Currently, there is no way to get a nice dashboard of all business processes. The `Show all` page only displays the Display Name of the process, but not of the nodes (css class `badge`), meaning the dashboard is not very informative.

This PR implements the `showFullscreen` and `showCompact` URL options to fix this (according to https://icinga.com/docs/icinga-web-2/latest/doc/20-Advanced-Topics/), allowing the use of https://example.com/icingaweb2/businessprocess?showFullscreen&showCompact as an overview dashboard.
![image](https://user-images.githubusercontent.com/24634880/120000382-0a7e8300-bfd3-11eb-8be1-850fd5ade8c1.png)
