### PR TITLE
Add state balls for acknowledged warning and unknown nodes

### DIFF
--- a/public/css/state-ball.less
+++ b/public/css/state-ball.less
@@ -13,8 +13,16 @@
     background-color: @color-unknown;
   }
 
+  &.state-unknown-handled {
+    background-color: @color-unknown-handled;
+  }
+
   &.state-warning {
     background-color: @color-warning;
+  }
+
+  &.state-warning-handled {
+    background-color: @color-warning-handled;
   }
 
   &.state-ok,


### PR DESCRIPTION
The state balls for acknowledged warning and unknown nodes were not addressed before, hence no state balls are shown in this case. This has been fixed in this pull request.

Before:

https://user-images.githubusercontent.com/33730024/134482261-3d282069-4592-4eff-82d0-3c95c05e247d.mov

After:

https://user-images.githubusercontent.com/33730024/134482738-c1ff4597-e675-42f0-be99-dafd54fd2eca.mov

