### PR TITLE
fix/state-can-be-empty-#325

### DIFF
--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -39,6 +39,7 @@ class BpNode extends Node
         'OK'                  => 0,
         'PENDING'             => 0,
         'MISSING'             => 0,
+        'EMPTY'               => 0,
     );
 
     protected static $sortStateInversionMap = array(


### PR DESCRIPTION
state can be empty
that index is missing in $emptyStateSummary
causes exceptions on business processes without nodes
fixes #325