### PR TITLE
Fix storing of business process with `Description` having new lines

### DIFF
--- a/library/Businessprocess/Storage/LegacyConfigRenderer.php
+++ b/library/Businessprocess/Storage/LegacyConfigRenderer.php
@@ -52,7 +52,18 @@ class LegacyConfigRenderer
                 continue;
             }
 
-            $str .= sprintf("# %-15s : %s\n", $key, $value);
+            $lineNum = 1;
+            $spaces = str_repeat(' ', strlen(sprintf("%-15s :", $key)));
+
+            foreach (preg_split('/\r?\n/', $value) as $line) {
+                if ($lineNum === 1) {
+                    $str .= sprintf("# %-15s : %s\n", $key, $line);
+                } else {
+                    $str .= sprintf("# %s %s\n", $spaces, $line);
+                }
+
+                $lineNum++;
+            }
         }
 
         $str .= "#\n###################################\n\n";


### PR DESCRIPTION
The `LegacyConfigRenderer::renderHeader()` should render new lines in the `Description` field as comments.

This fix avoids the occurrence of future issues due to new lines in `Description` field when adding or modifying the
business processes.

fixes #311 