### PR TITLE
Show critical count badge in left menu

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -1,9 +1,11 @@
 <?php
 
 use Icinga\Module\Businessprocess\Storage\LegacyStorage;
+use Icinga\Module\Businessprocess\Web\Navigation\Renderer\ProcessProblemsBadge;
 
 /** @var \Icinga\Application\Modules\Module $this */
 $section = $this->menuSection(N_('Business Processes'), array(
+    'renderer' => 'ProcessesProblemsBadge',
     'url'      => 'businessprocess',
     'icon'     => 'sitemap',
     'priority' => 46
@@ -30,6 +32,7 @@ try {
         }
 
         $section->add($meta->getTitle(), array(
+            'renderer' => (new ProcessProblemsBadge())->setBpConfigName($name),
             'url' => 'businessprocess/process/show',
             'urlParameters' => array('config' => $name),
             'priority' => $prio

--- a/library/Businessprocess/Web/Navigation/Renderer/ProcessProblemsBadge.php
+++ b/library/Businessprocess/Web/Navigation/Renderer/ProcessProblemsBadge.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Icinga\Module\Businessprocess\Web\Navigation\Renderer;
+
+use Icinga\Module\Businessprocess\Storage\LegacyStorage;
+use Icinga\Web\Navigation\Renderer\BadgeNavigationItemRenderer;
+
+class ProcessProblemsBadge extends BadgeNavigationItemRenderer
+{
+    /**
+     * Cached count
+     *
+     * @var int
+     */
+    protected $count;
+
+    /** @var string */
+    private $bpConfigName;
+
+    public function getCount()
+    {
+        if ($this->count === null) {
+            $storage = LegacyStorage::getInstance();
+            $count = 0;
+            $bp = $storage->loadProcess($this->getBpConfigName());
+
+
+            foreach ($bp->getRootNodes() as $rootNode) {
+                if (! $rootNode->isEmpty() &&
+                    $rootNode->getState() !== $rootNode::ICINGA_PENDING
+                    && $rootNode->hasProblems()) {
+                    $count++;
+                }
+            }
+
+            $this->count = $count;
+            $this->setState(self::STATE_CRITICAL);
+        }
+
+        if ($count) {
+            $this->setTitle(sprintf(
+                tp('One unhandled root node critical', '%d unhandled root nodes critical', $count),
+                $count
+            ));
+        }
+
+        return $this->count;
+    }
+
+    public function setBpConfigName($bpConfigName)
+    {
+        $this->bpConfigName = $bpConfigName;
+
+        return $this;
+    }
+
+    public function getBpConfigName()
+    {
+        return $this->bpConfigName;
+    }
+}

--- a/library/Businessprocess/Web/Navigation/Renderer/ProcessesProblemsBadge.php
+++ b/library/Businessprocess/Web/Navigation/Renderer/ProcessesProblemsBadge.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Icinga\Module\Businessprocess\Web\Navigation\Renderer;
+
+use Icinga\Application\Modules\Module;
+use Icinga\Module\Businessprocess\ProvidedHook\Icingadb\IcingadbSupport;
+use Icinga\Module\Businessprocess\State\IcingaDbState;
+use Icinga\Module\Businessprocess\State\MonitoringState;
+use Icinga\Module\Businessprocess\Storage\LegacyStorage;
+use Icinga\Web\Navigation\Renderer\BadgeNavigationItemRenderer;
+
+class ProcessesProblemsBadge extends BadgeNavigationItemRenderer
+{
+    /**
+     * Cached count
+     *
+     * @var int
+     */
+    protected $count;
+
+    public function getCount()
+    {
+        if ($this->count === null) {
+            $storage = LegacyStorage::getInstance();
+            $count = 0;
+
+            foreach ($storage->listProcessNames() as $processName) {
+                $bp = $storage->loadProcess($processName);
+                if (Module::exists('icingadb') &&
+                    (! $bp->hasBackendName() && IcingadbSupport::useIcingaDbAsBackend())
+                ) {
+                    IcingaDbState::apply($bp);
+                } else {
+                    MonitoringState::apply($bp);
+                }
+
+                foreach ($bp->getRootNodes() as $rootNode) {
+                    if (! $rootNode->isEmpty() &&
+                        $rootNode->getState() !== $rootNode::ICINGA_PENDING
+                        && $rootNode->hasProblems()) {
+                        $count++;
+                        break;
+                    }
+                }
+            }
+
+            $this->count = $count;
+            $this->setState(self::STATE_CRITICAL);
+        }
+
+        return $this->count;
+    }
+}


### PR DESCRIPTION
The critical count badge of `Business Process` menu section represent number configs that are in critical state.
The critical count badge of configs sub section under represent number of critical root nodes of that specific config.

ref #246