### PR TITLE
Show service and host nodes for filtered roles

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -44,7 +44,7 @@ class HostController extends Controller
 
             $this->params->add('name', $hostName);
 
-            if ($host !== false) {
+            if ($host !== null) {
                 $this->redirectNow(Url::fromPath('icingadb/host')->setParams($this->params));
             }
         } else {

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -49,7 +49,7 @@ class ServiceController extends Controller
             $this->params->add('name', $serviceName);
             $this->params->add('host.name', $hostName);
 
-            if ($service !== false) {
+            if ($service !== null) {
                 $this->redirectNow(Url::fromPath('icingadb/service')->setParams($this->params));
             }
         } else {

--- a/library/Businessprocess/State/IcingaDbState.php
+++ b/library/Businessprocess/State/IcingaDbState.php
@@ -63,8 +63,6 @@ class IcingaDbState
         }
 
         $queryHost = Host::on($this->backend)->with('state');
-        IcingaDbObject::applyIcingaDbRestrictions($queryHost);
-
         $queryHost->filter(Filter::equal('host.name', $hosts));
 
         $hostObject = $queryHost->getModel()->getTableName();
@@ -77,8 +75,6 @@ class IcingaDbState
             ->with('host.state');
 
         $queryService->filter(Filter::equal('host.name', $hosts));
-
-        IcingaDbObject::applyIcingaDbRestrictions($queryService);
 
         Benchmark::measure('Retrieved states for ' . $queryService->count() . ' services in ' . $config->getName());
 


### PR DESCRIPTION
The service and host nodes must be shown, but clicking on these nodes should show
"Access Denied" page.

fixes #345 