### PR TITLE
Show Ack/Downtime icons in the node tiles for the handled nodes

### DIFF
--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -13,6 +13,7 @@ use Icinga\Module\Businessprocess\ServiceNode;
 use Icinga\Web\Url;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
+use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\StateBall;
 
 class NodeTile extends BaseHtmlElement
@@ -262,6 +263,12 @@ class NodeTile extends BaseHtmlElement
                     Html::tag('i', ['class' => 'icon icon-host'])
                 ));
             }
+        }
+
+        if ($node->isAcknowledged()) {
+            $this->actions()->add(new Icon('check', ['class' => 'handled-icon']));
+        } elseif ($node->isInDowntime()) {
+            $this->actions()->add(new Icon('plug', ['class' => 'handled-icon']));
         }
     }
 

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -470,7 +470,7 @@ td > a > .state-badges {
 
     .actions {
         opacity: 0.8;
-        margin: 0.5em 0 0 0.5em;
+        margin: 0.5em 0.5em 0 0.5em;
         font-size: 0.75em;
         height: 1.8em;
 
@@ -482,6 +482,14 @@ td > a > .state-badges {
             line-height: normal;
             margin: 0;
             padding: 0 0 0 0.25em;
+
+            &.handled-icon {
+                display: inline-block;
+                margin-top: 0.15em;
+                float: right;
+                width: 1.5em;
+                height: 1.5em;
+            }
         }
         a {
             margin: 0;


### PR DESCRIPTION
In case the hosts/services are acknowledged or have scheduled downtime show Acknowledged or
Downtime icons respectively.

ref #237 