### PR TITLE
Show `Ack` icon in tree view for nodes with both downtime and acknowledgement

### DIFF
--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -133,12 +133,13 @@ class TreeRenderer extends Renderer
                 DateFormatter::timeSince($node->getLastStateChange())
             )
         ]);
-        if ($node->isInDowntime()) {
-            $icons[] = Html::tag('i', ['class' => 'icon icon-plug']);
-        }
+
         if ($node->isAcknowledged()) {
             $icons[] = Html::tag('i', ['class' => 'icon icon-ok']);
+        } elseif ($node->isInDowntime()) {
+            $icons[] = new Icon('plug');
         }
+
         return $icons;
     }
 

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -132,12 +132,8 @@ ul.bp {
             opacity: .8;
         }
 
-        i.icon-ok {
-            opacity: .8;
-        }
-
-        i.icon-plug {
-            opacity: .7;
+        span.state-ball ~ i:last-of-type {
+            margin-right: 0;
         }
     }
 


### PR DESCRIPTION
Acknowledgement takes priority in handled nodes and hence it is sufficient to show acknowledged icons in case the handled node has an acknowledgement and also a downtime is scheduled for it.

This change has already been implemented for tiles in #348

## Before
<img width="1026" alt="Screenshot 2022-09-20 at 11 08 57" src="https://user-images.githubusercontent.com/33730024/191221208-fe4d53fb-4bb3-411b-b1ec-a6be499a9b0e.png">

## After
<img width="1026" alt="Screenshot 2022-09-20 at 11 20 04" src="https://user-images.githubusercontent.com/33730024/191221324-1ffbf95d-4f64-48e2-b027-461bebcc14bf.png">
