### PR TITLE
Display node name if alias for monitoring node is missing

### DIFF
--- a/application/forms/DeleteNodeForm.php
+++ b/application/forms/DeleteNodeForm.php
@@ -31,15 +31,16 @@ class DeleteNodeForm extends QuickForm
     public function setup()
     {
         $node = $this->node;
+        $nodeName = $node->getAlias() ?? $node->getName();
         $view = $this->getView();
         $this->addHtml(
             '<h2>' . $view->escape(
-                sprintf($this->translate('Delete "%s"'), $node->getAlias())
+                sprintf($this->translate('Delete "%s"'), $nodeName)
             ) . '</h2>'
         );
 
         $biLink = $view->qlink(
-            $node->getAlias(),
+            $nodeName,
             'businessprocess/node/impact',
             array('name' => $node->getName()),
             array('data-base-target' => '_next')
@@ -61,7 +62,7 @@ class DeleteNodeForm extends QuickForm
         } else {
             $yesMsg = sprintf(
                 $this->translate('Delete root node "%s"'),
-                $this->node->getAlias()
+                $nodeName
             );
         }
 
@@ -74,7 +75,7 @@ class DeleteNodeForm extends QuickForm
             'multiOptions' => $this->optionalEnum(array(
                 'no'  => $this->translate('No'),
                 'yes' => $yesMsg,
-                'all' => sprintf($this->translate('Delete all occurrences of %s'), $node->getAlias()),
+                'all' => sprintf($this->translate('Delete all occurrences of %s'), $nodeName),
             ))
         ));
     }

--- a/application/forms/EditNodeForm.php
+++ b/application/forms/EditNodeForm.php
@@ -48,9 +48,10 @@ class EditNodeForm extends QuickForm
         }
 
         $view = $this->getView();
+        $nodeName = $this->getNode()->getAlias() ?? $this->getNode()->getName();
         $this->addHtml(
             '<h2>' . $view->escape(
-                sprintf($this->translate('Modify "%s"'), $this->getNode()->getAlias())
+                sprintf($this->translate('Modify "%s"'), $nodeName)
             ) . '</h2>'
         );
 

--- a/application/forms/SimulationForm.php
+++ b/application/forms/SimulationForm.php
@@ -44,7 +44,7 @@ class SimulationForm extends QuickForm
         }
         $this->addHtml(
             '<h2>'
-            . $view->escape(sprintf($title, $node->getAlias()))
+            . $view->escape(sprintf($title, $node->getAlias() ?? $node->getName()))
             . '</h2>'
         );
 

--- a/library/Businessprocess/MonitoredNode.php
+++ b/library/Businessprocess/MonitoredNode.php
@@ -11,9 +11,9 @@ abstract class MonitoredNode extends Node
     public function getLink()
     {
         if ($this->isMissing()) {
-            return Html::tag('a', ['href' => '#'], $this->getAlias());
+            return Html::tag('a', ['href' => '#'], $this->getAlias() ?? $this->getName());
         } else {
-            return Html::tag('a', ['href' => $this->getUrl()], $this->getAlias());
+            return Html::tag('a', ['href' => $this->getUrl()], $this->getAlias() ?? $this->getName());
         }
     }
 }

--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -180,7 +180,11 @@ class NodeTile extends BaseHtmlElement
         $node = $this->node;
         $url = $this->getMainNodeUrl($node);
         if ($node instanceof MonitoredNode) {
-            $link = Html::tag('a', ['href' => $url, 'data-base-target' => '_next'], $node->getAlias());
+            $link = Html::tag(
+                'a',
+                ['href' => $url, 'data-base-target' => '_next'],
+                $node->getAlias() ?? $node->getName()
+            );
         } else {
             $link = Html::tag('a', ['href' => $url], $node->getAlias());
         }

--- a/library/Businessprocess/ServiceNode.php
+++ b/library/Businessprocess/ServiceNode.php
@@ -65,6 +65,10 @@ class ServiceNode extends MonitoredNode
 
     public function getAlias()
     {
+        if ($this->getHostAlias() === null || $this->alias === null) {
+            return null;
+        }
+
         return $this->getHostAlias() . ': ' . $this->alias;
     }
 


### PR DESCRIPTION
When a monitoring node is missing, its alias is also missing. So in this case we should display the node name.