### PR TITLE
Extend the width of multiselect-elements Add/ Edit Business-Processes

### DIFF
--- a/application/forms/AddNodeForm.php
+++ b/application/forms/AddNodeForm.php
@@ -203,7 +203,7 @@ class AddNodeForm extends QuickForm
             'label'        => $this->translate('Hosts'),
             'required'     => true,
             'size'         => 8,
-            'style'        => 'width: 25em',
+            'style'        => 'width: 45em',
             'multiOptions' => $this->enumHostList(),
             'description'  => $this->translate(
                 'Hosts that should be part of this business process node'
@@ -249,7 +249,7 @@ class AddNodeForm extends QuickForm
             'label'        => $this->translate('Services'),
             'required'     => true,
             'size'         => 8,
-            'style'        => 'width: 25em',
+            'style'        => 'width: 45em',
             'multiOptions' => $this->enumServiceList($host),
             'description'  => $this->translate(
                 'Services that should be part of this business process node'
@@ -268,7 +268,7 @@ class AddNodeForm extends QuickForm
             'label'        => $this->translate('Hosts'),
             'required'     => true,
             'size'         => 8,
-            'style'        => 'width: 25em',
+            'style'        => 'width: 45em',
             'multiOptions' => $this->enumHostListByFilter($filter),
             'description'  => $this->translate(
                 'Hosts that should be part of this business process node'
@@ -287,7 +287,7 @@ class AddNodeForm extends QuickForm
             'label'        => $this->translate('Services'),
             'required'     => true,
             'size'         => 8,
-            'style'        => 'width: 25em',
+            'style'        => 'width: 45em',
             'multiOptions' => $this->enumServiceListByFilter($filter),
             'description'  => $this->translate(
                 'Services that should be part of this business process node'

--- a/application/forms/EditNodeForm.php
+++ b/application/forms/EditNodeForm.php
@@ -288,7 +288,7 @@ class EditNodeForm extends QuickForm
             'label'        => $this->translate('Process nodes'),
             'required'     => true,
             'size'         => 8,
-            'style'        => 'width: 25em',
+            'style'        => 'width: 45em',
             'multiOptions' => $this->enumProcesses(),
             'description'  => $this->translate(
                 'Other processes that should be part of this business process node'


### PR DESCRIPTION
We have issues when adding new hosts or services to business processes because the length of the dropdown menus are quite short. 
In the age of curved widescreens there is huge blank space (and I don't even use a widescreen at the moment :))
FYI: The longest service-name in the screenshot has 47 characters.

## Screenshots
![image](https://github.com/Icinga/icingaweb2-module-businessprocess/assets/67681686/9808297a-d446-4ded-81fd-98139990ba15)
