### PR TITLE
LegacyConfigParser: Ignore empty lines in `parseHeaderLine()`

### DIFF
--- a/library/Businessprocess/Storage/LegacyConfigParser.php
+++ b/library/Businessprocess/Storage/LegacyConfigParser.php
@@ -196,6 +196,10 @@ class LegacyConfigParser
      */
     protected static function parseHeaderLine($line, Metadata $metadata)
     {
+        if (empty($line)) {
+            return;
+        }
+
         if (preg_match('/^\s*#\s+(.+?)\s*:\s*(.+)$/', trim($line), $m)) {
             if ($metadata->hasKey($m[1])) {
                 static::$prevKey = $m[1];


### PR DESCRIPTION
fixes #377 