### PR TITLE
BpNode::getMissingChildren(): Use child name if alias not given

### DIFF
--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -275,11 +275,11 @@ class BpNode extends Node
 
             foreach ($this->getChildren() as $child) {
                 if ($child->isMissing()) {
-                    $missing[$child->getAlias()] = $child;
+                    $missing[$child->getAlias() ?? $child->getName()] = $child;
                 }
 
                 foreach ($child->getMissingChildren() as $m) {
-                    $missing[$m->getAlias()] = $m;
+                    $missing[$m->getAlias() ?? $m->getName()] = $m;
                 }
             }
 


### PR DESCRIPTION
fixes #398 