### PR TITLE
Disable the default Safari detail marker

### DIFF
--- a/public/css/module.less
+++ b/public/css/module.less
@@ -172,6 +172,10 @@ ul.bp {
         border-bottom: 1px solid @gray-light;
         user-select: none;
 
+        &::-webkit-details-marker {
+            display:none;
+        }
+
         > .icon:nth-child(1),
         > .icon:nth-child(2) {
             min-width: 1.3em; // So that process icons align with their node's icons


### PR DESCRIPTION
As we use our own icons to represent the detail state, the default detail marker rendered by Safari must be hidden.

fixes #406