### PR TITLE
Backport #337 to support/2.4

### DIFF
--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -82,6 +82,8 @@ class BpNode extends Node
                         $this->counters['UNKNOWN']++;
                     } elseif ($state === 'UNREACHABLE-HANDLED') {
                         $this->counters['UNKNOWN-HANDLED']++;
+                    } elseif ($state === 'PENDING-HANDLED') {
+                        $this->counters['PENDING']++;
                     } elseif ($state === 'UP') {
                         $this->counters['OK']++;
                     } else {


### PR DESCRIPTION
Increment `PENDING` state summary counter of the BP node in case there are `PENDING-HANDLED` child/children node/s.

(cherry picked from commit 731541e667de8670071a9ee1765b1da6af4e3069)