### PR TITLE
Fix: Switching to the icingadb backend and searching host/service node in add/edit form throws an error

### DIFF
--- a/library/Businessprocess/Web/Form/Validator/HostServiceTermValidator.php
+++ b/library/Businessprocess/Web/Form/Validator/HostServiceTermValidator.php
@@ -45,7 +45,8 @@ class HostServiceTermValidator extends BaseValidator
         }
 
         $isValid = true;
-        $testConfig = new BpConfig();
+        $testConfig = (new BpConfig())
+            ->setBackend($this->parent->getBpConfig()->getBackend());
 
         foreach ($terms as $term) {
             /** @var Term $term */
@@ -68,7 +69,7 @@ class HostServiceTermValidator extends BaseValidator
             }
         }
 
-        if ($this->parent->getBpConfig()->getBackend() instanceof MonitoringBackend) {
+        if ($testConfig->getBackend() instanceof MonitoringBackend) {
             MonitoringState::apply($testConfig);
         } else {
             IcingaDbState::apply($testConfig);

--- a/phpstan-baseline-standard.neon
+++ b/phpstan-baseline-standard.neon
@@ -4346,16 +4346,6 @@ parameters:
 			path: library/Businessprocess/Web/Form/QuickForm.php
 
 		-
-			message: "#^Call to an undefined method Icinga\\\\Module\\\\Businessprocess\\\\BpNode\\|Icinga\\\\Module\\\\Businessprocess\\\\MonitoredNode\\:\\:addChild\\(\\)\\.$#"
-			count: 1
-			path: library/Businessprocess/Web/Form/Validator/HostServiceTermValidator.php
-
-		-
-			message: "#^Parameter \\#1 \\$label of method ipl\\\\Web\\\\FormElement\\\\TermInput\\\\Term\\:\\:setLabel\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: library/Businessprocess/Web/Form/Validator/HostServiceTermValidator.php
-
-		-
 			message: "#^Method Icinga\\\\Module\\\\Businessprocess\\\\Web\\\\Navigation\\\\Renderer\\\\ProcessProblemsBadge\\:\\:getBpConfigName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: library/Businessprocess/Web/Navigation/Renderer/ProcessProblemsBadge.php


### PR DESCRIPTION
`HostServiceTermValidator`: `$testConfig` requires backend for `MonitoringState::apply()` call.

If the `$testConfig` has no backend set and icingadb is in use, `MonitoringState::__construct($config) => $config->getBackend()` returns an icingadb backend that is not suitable for the `MonitoringState` class.

fixes https://github.com/Icinga/icingaweb2-module-businessprocess/issues/430