### PR TITLE
Feature: Add businessprocess/showall/readonly permission

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -43,8 +43,12 @@ try {
 }
 
 $this->providePermission(
+    'businessprocess/showall/readonly',
+    $this->translate('Allow to see all available processes, regardless of configured restrictions. Permissions are restricted.')
+);
+$this->providePermission(
     'businessprocess/showall',
-    $this->translate('Allow to see all available processes, regardless of configured restrictions')
+    $this->translate('Allow to see all available processes, regardless of configured restrictions. Permissions are not restricted.'),
 );
 $this->providePermission(
     'businessprocess/create',

--- a/doc/31-Permissions.md
+++ b/doc/31-Permissions.md
@@ -9,7 +9,8 @@ The module has five levels of permissions:
 * Granting general module access allows a user to view business processes. (`module/businessprocess`)
 * Create permissions allow to create new business processes. (`businessprocess/create`)
 * Modify permissions allow to modify already existing ones. (`businessprocess/modify`)
-* Permission to view all business processes regardless restrictions. (`businessprocess/showall`)
+* Permission to view all business processes regardless restrictions. Other permissions will be restricted. (`businessprocess/showall/read`)
+* Permission to view all business processes regardless restrictions. Other permissions won't be restricted. (`businessprocess/showall/inherit`)
 * Full permissions. (`businessprocess/*`)
 
 ## Restrictions

--- a/library/Businessprocess/Metadata.php
+++ b/library/Businessprocess/Metadata.php
@@ -122,9 +122,19 @@ class Metadata
             }
         }
 
+        if ($auth->hasPermission('businessprocess/showall/readonly') &&  ! $auth->hasPermission('businessprocess/showall')) {
+            $prefixes = $auth->getRestrictions('businessprocess/prefix');
+            if (! empty($prefixes)) {
+                if (! $this->nameIsPrefixedWithOneOf($prefixes)) {
+                    return false;
+                }
+            }
+        }
+
         return $this->canRead($auth) && (
-            $auth->hasPermission('businessprocess/modify')
-            || $this->ownerIs($auth->getUser()->getUsername())
+            $auth->hasPermission('businessprocess/modify') ||
+            $this->ownerIs($auth->getUser()->getUsername()
+            )
         );
     }
 
@@ -139,6 +149,10 @@ class Metadata
         }
 
         if ($auth->hasPermission('businessprocess/showall')) {
+            return true;
+        }
+
+        if ($auth->hasPermission('businessprocess/showall/readonly')) {
             return true;
         }
 


### PR DESCRIPTION
## Is your feature request related to a problem? Please describe.
Following Scenario is not possible:
  1. Role A has write access to BP A
  2. Role B has write access to BP B
  3. Role A needs also read access to BP B. The same applies vice versa for Role B

Background: 
Team A wants to administrate its BP A but also needs to see BP B. Again, the same applies vice versa for Team B. Currently this is only possible with two accounts for both Teams. One with `write` access that can't see any others. Another one with the `showall` permission, **but** no `create` or `modify`. As soon as `create` or `modify` are combined with `showall` it is the same as `businessprocess/*` which means full access.  

The second option is to add only one user per Team with write access. Then with another additional User, which can be accessed by both teams, they can read all but not write.

The issue is in big systems this means to administrate twice as much accounts.

`showall` definitely has its justification for existence, but it is a little bit confusing and I think this PR will clarify a lot of questions of our customers in the future since we now have a `businessprocess/showall/readonly` option. 

ref/NC/806896

## Describe the solution you'd like
The solution should be to have one user that only can write on his own BP restricted by prefix and read all other BPs. This PR offers that solution.

## Describe alternatives you've considered
I considered a lot of alternatives but this solution clarifies the options and doesn't change anything in the code. It just adds an additional "check" to canModify(). The new naming also clarifies the permissions and now it is possible to manage that scenario with one user per Team, but feel free to change the PR as you want.

Also it doesn't break any existing installation.