### PR TITLE
Add confirmation when deleting a business process

### DIFF
--- a/application/forms/BpConfigForm.php
+++ b/application/forms/BpConfigForm.php
@@ -139,7 +139,8 @@ class BpConfigForm extends BpConfigBaseForm
 
             $label = $this->translate('Delete');
             $el = $this->createElement('submit', $label, array(
-                'data-base-target' => '_main'
+                'data-base-target' => '_main',
+                'onclick'          => sprintf('return confirm("%s")', $this->translate('Confirm deletion')),
             ))->setLabel($label)->setDecorators(array('ViewHelper'));
             $this->deleteButtonName = $el->getName();
             $this->addElement($el);


### PR DESCRIPTION
This adds a confirmation to the delete operation using the browsers `window.confirm()` 

Fixes #431 