### PR TITLE
Add options for number of shown menu items

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -1,0 +1,54 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Businessprocess\Controllers;
+
+use Icinga\Application\Config;
+use Icinga\Module\Businessprocess\Forms\GeneralConfigForm;
+use Icinga\Web\Notification;
+use Icinga\Web\Widget\Tabs;
+use ipl\Html\Contract\Form;
+use ipl\Web\Compat\CompatController;
+
+class ConfigController extends CompatController
+{
+    public function init(): void
+    {
+        $this->assertPermission('config/modules');
+
+        parent::init();
+    }
+
+    public function generalAction(): void
+    {
+        $this->mergeTabs($this->Module()->getConfigTabs()->activate('general'));
+
+        $config = Config::module('businessprocess');
+        $form = (new GeneralConfigForm())
+            ->populate($config->getSection('general'))
+            ->on(Form::ON_SUBMIT, function (GeneralConfigForm $form) use ($config) {
+                $config->setSection('general', $form->getValues());
+                $config->saveIni();
+
+                Notification::success($this->translate('New configuration saved successfully'));
+            })->handleRequest($this->getServerRequest());
+
+        $this->addContent($form);
+    }
+
+    /**
+     * Merge tabs with other tabs contained in this tab panel
+     *
+     * @param Tabs $tabs
+     *
+     * @return void
+     */
+    protected function mergeTabs(Tabs $tabs): void
+    {
+        foreach ($tabs->getTabs() as $tab) {
+            $this->tabs->add($tab->getName(), $tab);
+        }
+    }
+}

--- a/application/forms/GeneralConfigForm.php
+++ b/application/forms/GeneralConfigForm.php
@@ -1,0 +1,33 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Businessprocess\Forms;
+
+use ipl\Validator\GreaterThanValidator;
+use ipl\Web\Compat\CompatForm;
+
+class GeneralConfigForm extends CompatForm
+{
+    /** @var int Default number of maximum allowed processes in the sidebar menu */
+    public const MAX_MENU_PROCESSES = 5;
+
+    protected function assemble(): void
+    {
+        $this->addElement(
+            'number',
+            'max_menu_processes',
+            [
+                'label'       => $this->translate('Max Menu Processes'),
+                'description' => $this->translate('Max allowed processes in sidebar menu'),
+                'placeholder' => '5',
+                'value'       => static::MAX_MENU_PROCESSES,
+                'min'         => 0,
+                'validators'  => [new GreaterThanValidator(['min' => 0])]
+            ]
+        );
+
+        $this->addElement('submit', 'submit', ['label' => $this->translate('Save Changes')]);
+    }
+}

--- a/configuration.php
+++ b/configuration.php
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2018 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use Icinga\Application\Config;
+use Icinga\Module\Businessprocess\Forms\GeneralConfigForm;
 use Icinga\Module\Businessprocess\Storage\LegacyStorage;
 use Icinga\Module\Businessprocess\Web\Navigation\Renderer\ProcessProblemsBadge;
 
@@ -16,30 +18,35 @@ $section = $this->menuSection(N_('Business Processes'), array(
 
 try {
     $storage = LegacyStorage::getInstance();
+    $maxMenuProcesses = Config::module('businessprocess')
+        ->getSection('general')
+        ->get('max_menu_processes', GeneralConfigForm::MAX_MENU_PROCESSES);
 
-    $prio = 0;
-    foreach ($storage->listProcessNames() as $name) {
-        $meta = $storage->loadMetadata($name);
-        if ($meta->get('AddToMenu') === 'no') {
-            continue;
-        }
-        $prio++;
+    if ($maxMenuProcesses > 0) {
+        $prio = 0;
+        foreach ($storage->listProcessNames() as $name) {
+            $meta = $storage->loadMetadata($name);
+            if ($meta->get('AddToMenu') === 'no') {
+                continue;
+            }
+            $prio++;
 
-        if ($prio > 5) {
-            $section->add(N_('Show all'), array(
-                'url' => 'businessprocess',
+            if ($prio > $maxMenuProcesses) {
+                $section->add(N_('Show all'), array(
+                    'url' => 'businessprocess',
+                    'priority' => $prio
+                ));
+
+                break;
+            }
+
+            $section->add($meta->getTitle(), array(
+                'renderer' => (new ProcessProblemsBadge())->setBpConfigName($name),
+                'url' => 'businessprocess/process/show',
+                'urlParameters' => array('config' => $name),
                 'priority' => $prio
             ));
-
-            break;
         }
-
-        $section->add($meta->getTitle(), array(
-            'renderer' => (new ProcessProblemsBadge())->setBpConfigName($name),
-            'url' => 'businessprocess/process/show',
-            'urlParameters' => array('config' => $name),
-            'priority' => $prio
-        ));
     }
 } catch (Exception $e) {
     // Well... there is not much we could do here
@@ -60,6 +67,15 @@ $this->providePermission(
 $this->provideRestriction(
     'businessprocess/prefix',
     $this->translate('Restrict access to configurations with the given prefix')
+);
+
+$this->provideConfigTab(
+    'general',
+    [
+        'title' => $this->translate('General'),
+        'label' => $this->translate('General'),
+        'url'   => 'config/general'
+    ]
 );
 
 $this->provideJsFile('vendor/Sortable.js');

--- a/doc/03-Getting-Started.md
+++ b/doc/03-Getting-Started.md
@@ -55,8 +55,8 @@ calculating the state of a Business Process definition.
 
 ### Add to menu
 
-Business Process configurations can be linked to the Icinga Web 2 menu. Only the
-first five configurations a user is allowed to see will be shown there:
+Business Process configurations can be linked to the Icinga Web menu. By default, the
+first five items are shown. This can be adjusted in the module's general configuration.
 
 ![Add to menu](screenshot/03_getting-started/0208_create-new_add-to-menu.png)
 


### PR DESCRIPTION
This PR adds a **general** config tab with one option to set the number of items to show in the sidebar menu. Before it was a fixed number of **five**. I kept that number as the default if none is provided.

resolves #482 